### PR TITLE
feat(api): Implement endpoint to fetch all products

### DIFF
--- a/src/main/java/dev/dipanshu/productservice/controllers/ProductController.java
+++ b/src/main/java/dev/dipanshu/productservice/controllers/ProductController.java
@@ -8,6 +8,8 @@ import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RestController;
 
+import java.util.List;
+
 @RestController
 public class ProductController {
 
@@ -22,8 +24,8 @@ public class ProductController {
     }
 
     @GetMapping("/products")
-    public void getAllProducts(){
-
+    public List<Product> getAllProducts(){
+        return productService.getProducts();
     }
 
     @GetMapping("/products/{id}")

--- a/src/main/java/dev/dipanshu/productservice/dtos/FakeStoreProductDtoList.java
+++ b/src/main/java/dev/dipanshu/productservice/dtos/FakeStoreProductDtoList.java
@@ -1,0 +1,16 @@
+package dev.dipanshu.productservice.dtos;
+
+import lombok.Getter;
+import lombok.Setter;
+
+import java.util.List;
+
+@Getter
+@Setter
+public class FakeStoreProductDtoList {
+    private List<FakeStoreProductDto> products;
+
+    public List<FakeStoreProductDto> getProducts() {
+        return this.products;
+    }
+}

--- a/src/main/java/dev/dipanshu/productservice/services/FakeStoreProductService.java
+++ b/src/main/java/dev/dipanshu/productservice/services/FakeStoreProductService.java
@@ -1,10 +1,17 @@
 package dev.dipanshu.productservice.services;
 
 import dev.dipanshu.productservice.dtos.FakeStoreProductDto;
+import dev.dipanshu.productservice.dtos.FakeStoreProductDtoList;
 import dev.dipanshu.productservice.models.Category;
 import dev.dipanshu.productservice.models.Product;
+import org.springframework.core.ParameterizedTypeReference;
+import org.springframework.http.HttpMethod;
+import org.springframework.http.ResponseEntity;
 import org.springframework.stereotype.Component;
 import org.springframework.web.client.RestTemplate;
+
+import java.util.ArrayList;
+import java.util.List;
 
 @Component
 public class FakeStoreProductService implements ProductService{
@@ -31,5 +38,40 @@ public class FakeStoreProductService implements ProductService{
 
         return product;
 
+    }
+
+    public List<Product> getProducts(){
+//        FakeStoreProductDtoList fakeStoreProductDtoList = restTemplate
+//                .getForObject("https://fakestoreapi.com/products",
+//                        FakeStoreProductDtoList.class);
+//
+//        List<FakeStoreProductDto> dtoList = fakeStoreProductDtoList.getProducts();
+//        List<Product> products = new ArrayList<>();
+        ResponseEntity<List<FakeStoreProductDto>> responseEntity = restTemplate.exchange(
+                "https://fakestoreapi.com/products",
+                HttpMethod.GET,
+                null,
+                new ParameterizedTypeReference<List<FakeStoreProductDto>>() {}
+        );
+
+        List<FakeStoreProductDto> dtoList = responseEntity.getBody();
+        List<Product> products = new ArrayList<>();
+
+        for(FakeStoreProductDto dto : dtoList) {
+
+            Product product = new Product();
+            product.setId(dto.getId());
+            product.setTitle(dto.getTitle());
+            product.setDescription(dto.getDescription());
+            product.setImageUrl(dto.getImage());
+
+            Category category = new Category();
+            category.setTitle(dto.getCategory());
+            product.setCategory(category);
+
+            products.add(product);
+        }
+
+        return products;
     }
 }

--- a/src/main/java/dev/dipanshu/productservice/services/ProductService.java
+++ b/src/main/java/dev/dipanshu/productservice/services/ProductService.java
@@ -1,7 +1,11 @@
 package dev.dipanshu.productservice.services;
 
+import dev.dipanshu.productservice.ProductServiceApplication;
 import dev.dipanshu.productservice.models.Product;
+
+import java.util.List;
 
 public interface ProductService {
     public Product getSingleProduct(Long id);
+    public List<Product> getProducts();
 }


### PR DESCRIPTION
This commit introduces a new API endpoint to fetch all products. The ProductController now handles the '/products' endpoint, allowing clients to retrieve a collection of products. The FakeStoreProductService has been updated to fetch multiple products from the third-party API using RestTemplate. Additionally, the FakeStoreProductDto has been adjusted to accommodate the structure of the response containing multiple products.
BREAKING CHANGE: The API response format for fetching products has been updated to return a collection of products instead of a single product.
#ID02