### PR TITLE
feat(api): Implement endpoint to fetch product categories

### DIFF
--- a/src/main/java/dev/dipanshu/productservice/controllers/ProductController.java
+++ b/src/main/java/dev/dipanshu/productservice/controllers/ProductController.java
@@ -36,6 +36,11 @@ public class ProductController {
         return productService.getSingleProduct(id);
     }
 
+    @GetMapping("/products/categories")
+    public List<String> getProductCategories(){
+        return productService.getProductCategories();
+    }
+
     public void deleteProduct(Long id){
 
     }

--- a/src/main/java/dev/dipanshu/productservice/services/FakeStoreProductService.java
+++ b/src/main/java/dev/dipanshu/productservice/services/FakeStoreProductService.java
@@ -11,6 +11,7 @@ import org.springframework.stereotype.Component;
 import org.springframework.web.client.RestTemplate;
 
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.List;
 
 @Component
@@ -73,5 +74,14 @@ public class FakeStoreProductService implements ProductService{
         }
 
         return products;
+    }
+
+    @Override
+    public List<String> getProductCategories() {
+        String[] categories = restTemplate.getForObject(
+                "https://fakestoreapi.com/products/categories",
+                    String[].class);
+
+        return Arrays.asList(categories);
     }
 }

--- a/src/main/java/dev/dipanshu/productservice/services/ProductService.java
+++ b/src/main/java/dev/dipanshu/productservice/services/ProductService.java
@@ -8,4 +8,5 @@ import java.util.List;
 public interface ProductService {
     public Product getSingleProduct(Long id);
     public List<Product> getProducts();
+    public List<String> getProductCategories();
 }


### PR DESCRIPTION
This commit introduces a new API endpoint to fetch product categories from the third-party API. Updated the ProductController to handle the '/products/categories' endpoint, allowing clients to retrieve a list of product categories. Modified the FakeStoreProductService to fetch categories from the 'https://fakestoreapi.com/products/categories' endpoint using RestTemplate. No changes were required in the DTO classes as the API response contains a simple list of category strings. #ID03