### PR TITLE
feat: Implement deleteProduct API using RestTemplate.exchange method

### DIFF
--- a/src/main/java/dev/dipanshu/productservice/controllers/ProductController.java
+++ b/src/main/java/dev/dipanshu/productservice/controllers/ProductController.java
@@ -56,7 +56,8 @@ public class ProductController {
         return productService.updateProductPatch(id, product);
     }
 
-    public void deleteProduct(Long id){
-
+    @DeleteMapping("/products/{id}")
+    public Product deleteProduct(@PathVariable("id") Long id){
+        return productService.deleteProduct(id);
     }
 }

--- a/src/main/java/dev/dipanshu/productservice/services/FakeStoreProductService.java
+++ b/src/main/java/dev/dipanshu/productservice/services/FakeStoreProductService.java
@@ -106,4 +106,17 @@ public class FakeStoreProductService implements ProductService{
         
         return responseEntity.getBody();
     }
+
+    @Override
+    public Product deleteProduct(Long id) {
+        String url = "https://fakestoreapi.com/products/{id}";
+        ResponseEntity<FakeStoreProductDto> responseEntity = restTemplate.exchange(
+                url,
+                HttpMethod.DELETE,
+                null,
+                FakeStoreProductDto.class,
+                id
+        );
+        return responseEntity.getBody().toProduct();
+    }
 }

--- a/src/main/java/dev/dipanshu/productservice/services/ProductService.java
+++ b/src/main/java/dev/dipanshu/productservice/services/ProductService.java
@@ -14,4 +14,5 @@ public interface ProductService {
     public List<String> getProductCategories();
     public Product updateProductPut(Long id, Product product);
     public Product updateProductPatch(Long id, Product product);
+    public Product deleteProduct(Long id);
 }


### PR DESCRIPTION
This commit introduces the deleteProduct API method, which uses the RestTemplate.exchange method to perform an HTTP DELETE request to the external API. The method takes a product ID as an argument and sends a request to the specified URL, including the ID as a URI variable. The response is captured in a ResponseEntity<FakeStoreProductDto>, which holds the response body (if present) and the HTTP status code. If a valid FakeStoreProductDto is returned, the method converts it to a Product object and returns it. This initial implementation of the deleteProduct API provides a way to remove a product by its ID and appropriately handle the server's response. #ID12